### PR TITLE
Filter annotations to the current page

### DIFF
--- a/gopath/src/npserver/http_annotation.go
+++ b/gopath/src/npserver/http_annotation.go
@@ -46,6 +46,14 @@ func addAnnotationHandler(rw http.ResponseWriter, req *http.Request) {
 	annot.CreateDate = time.Now()
 	annot.Comments = []Comment{}
 
+	// Normalize the coordinates: X1,Y1 at top left, X2,Y2 as bottom right.
+	for _, coord := range annot.Locations {
+		coord.X1 = min(coord.X1, coord.X2)
+		coord.X2 = max(coord.X1, coord.X2)
+		coord.Y1 = min(coord.Y1, coord.Y2)
+		coord.Y2 = max(coord.Y1, coord.Y2)
+	}
+
 	log.Printf("\n\nAnnotation to insert is: %#v\n", *annot)
 
 	err = insertAnnotation(annot)
@@ -130,4 +138,21 @@ func addCommentHandler(rw http.ResponseWriter, req *http.Request) {
 	rw.WriteHeader(200)
 	rw.Write(j)
 	return
+}
+
+// Because package Math doesn't have Max and Min for float32...
+func min(a, b float32) float32 {
+	if a < b {
+		return a
+	} else {
+		return b
+	}
+}
+
+func max(a, b float32) float32 {
+	if a > b {
+		return a
+	} else {
+		return b
+	}
 }

--- a/http-files/html/document.html
+++ b/http-files/html/document.html
@@ -138,13 +138,32 @@
 
 		</div> <!-- pageView -->
 
+		<!-- Show the login button if not signed in -->
+		<div ng-show="account.username && !highlight.x1" >
+			Please highlight the document to create an annotation.
+		</div>
+
+		<div ng-show="highlight.x1" >
+			<div ng-show="account.username" >
+				<!-- when logged in and having a higlight: show the Annotate-button -->
+				<div class="btn btn-default" ng-click="addAnnotation()">Add a Annotation</div>
+			</div>
+		</div>
+
+		<div ng-hide="account.username" >
+		  <!-- we have a highlight but no auth, let user auth -->
+		  You need to log in before you can add an Annotation. 
+		  <a class="btn btn-default" href="#/sign-in/">Sign In</a>
+		</div>
+
+
 		<h3>Annotations</h3>
-		<div ng-repeat="annotation in annotations">
+		<div ng-repeat="annotation in annotationsOnPage(currentPage.number)">
 			<p class="np-document-description">{{ annotation.Annotation }}</p>
 			<p>By: {{ annotation.AnnotatorUsername }}</p>
 			<p>Date: {{annotation.CreateDate | date:'dd MMMM yyyy, HH:mm'}}</p>
 			<p>Coordinates: {{ annotation.Locations }}</p>
-			<p>The wisdom: <strong><span  class="highlight-transparency" style="background-color:{{ annotation.Color }}">{{ annotation.AnnotationText }}</span></strong></p>
+			<p>The annotation: <strong><span  class="highlight-transparency" style="background-color:{{ annotation.Color }}">{{ annotation.AnnotationText }}</span></strong></p>
 			
 			<div ng-repeat="comment in annotation.Comments">
 				<h4>Comment</h4>
@@ -182,34 +201,6 @@
 		</div> <!-- annotation in annotations -->
 		<br><hr>
 			
-		<!--
-			Here you can create an annotation... 
-			This is the interface we need.
-			Someone might want to rewrite it with a nice pointy-clicky user interface. It should give the coordinates:
-			ng-model="locations" value: { [ { PageNumber, x1, y1, x2, y2 }, ... ] } 
-			We allow for multiple coordinates. These should be used when a single rectancle won't fit. 
-			For example when the selection starts indented. Or when an quote spans page boundaries. (future version).
-			The server will add Annotator-Username and date-created.
-		-->
-
-		<!-- Show the login button if not signed in -->
-		
-		<div ng-show="account.username && !highlight.x1" >
-			Please highlight the document to create an annotation.
-		</div>
-
-		<div ng-show="highlight.x1" >
-			<div ng-show="account.username" >
-				<!-- when logged in and having a higlight: show the Annotate-button -->
-				<div class="btn btn-default" ng-click="addAnnotation()">Add a Annotation</div>
-			</div>
-
-			<div ng-hide="account.username" >
-				<!-- we have a highlight but no auth, let user auth -->
-				You need to log in before you can add an Annotation. 
-				<a class="btn btn-default" href="#/sign-in/">Sign In</a>
-			</div>
-		</div>
 
 	</div><!-- row -->
 </div><!-- container -->

--- a/http-files/js/nulpunt.js
+++ b/http-files/js/nulpunt.js
@@ -287,23 +287,28 @@ nulpunt.controller("DocumentCtrl", function($scope, $http, $routeParams, $modal)
 	});
 
     // get any annotation that has coordinates at the given pageNr.
-    function annotationsOnPage(pageNr) {
-	// console.log("filter annotations on page: ", pageNr);
+    $scope.annotationsOnPage = function(pageNr) {
+	console.log("filter annotations on page: ", pageNr);
+	console.log("annotatations in scope: ", $scope.annotations);
 	annotations = _.filter($scope.annotations, function(ann) {
 	    return _.some(ann.Locations, function(loc) { 
+		console.log("found: ", loc);
 		return loc.PageNumber == pageNr;
 	    })
-	})	   
+	})
+	console.log("returning: ", annotations);
 	return annotations
     }
 
     function clearHighlights() {
 	$("#highlights").html("");
+	document.getElementById("cvPage").width = 0;
+	document.getElementById("cvPage").height = 0;
     }
 
     function updateHighlights() {
 	//console.log("updateHighlights is called");
-	anns = annotationsOnPage($scope.currentPage.number);
+	anns = $scope.annotationsOnPage($scope.currentPage.number);
 	_.each(anns, function(ann) {
 	    _.each(ann.Locations, function(location) {
 		if (location.PageNumber == $scope.currentPage.number) {


### PR DESCRIPTION
Moved the add-annotation button to the top of the annotations.
Normalise coordinatas so the X1,Y1 is top left, irrespective of how the user selected it.
