### PR TITLE
Sort tag-search by upload-date and limit to published=yes

### DIFF
--- a/gopath/src/npserver/document.go
+++ b/gopath/src/npserver/document.go
@@ -29,10 +29,19 @@ func getDocument(selection interface{}) (*Document, error) {
 }
 
 // getDocuments gets all documents based upon the specified selection.
-// Selection must lead to a unique document. Otherwise, results are undefined
 func getDocuments(selection interface{}) ([]Document, error) {
 	docs := []Document{}
 	err := colDocuments.Find(selection).All(&docs)
+	if err != nil {
+		return nil, err
+	}
+	return docs, nil
+}
+
+// getDocuments gets all documents based upon the specified selection.
+func getOrderedDocuments(selection interface{}, order string) ([]Document, error) {
+	docs := []Document{}
+	err := colDocuments.Find(selection).Sort(order).All(&docs)
 	if err != nil {
 		return nil, err
 	}

--- a/gopath/src/npserver/http_document.go
+++ b/gopath/src/npserver/http_document.go
@@ -206,7 +206,7 @@ func getDocumentsByTagsHandler(rw http.ResponseWriter, req *http.Request) {
 
 		// create the selector
 
-		docs, err := getDocuments(bson.M{"tags": bson.M{"$in": params.Tags}})
+		docs, err := getOrderedDocuments(bson.M{"tags": bson.M{"$in": params.Tags}, "published": true}, "-uploadDate")
 		if err != nil {
 			log.Printf("GetDocuments error %#v\n", err)
 			http.Error(rw, "GetDocuments error", http.StatusNotFound) // 404


### PR DESCRIPTION
Upload-date is the closest to date of publication on nulpunt, so the newest documents get shown first.
